### PR TITLE
gradle: buildToolsVersion 19.1.0 (was 19.0.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 gen/
 bin/
 build/
+/Android-AccountChooser.iml

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ In the end call, instead of `AccountManager#newChooseAccountIntent`:
 AccountChooser.newChooseAccountIntent(
 	selectedAccount, allowableAccounts, allowableAccountTypes,
 	alwaysPromptForAccount, descriptionOverrideText, addAccountAuthTokenType,
-	addAccountRequiredFeatures, addAccountOptions);
+	addAccountRequiredFeatures, addAccountOptions, context);
 ```
 
 `AccountChooser` will then automatically detect the `Build.VERSION` number and use the most appropriate implementation, choosing from:

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 
 android {
     compileSdkVersion 19
-    buildToolsVersion "19.1.0"
+    buildToolsVersion "20"
 
     sourceSets {
         main {

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 
 android {
     compileSdkVersion 19
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "19.1.0"
 
     sourceSets {
         main {


### PR DESCRIPTION
Build Tools 19.1 is required when using Android Studio 0.6.0.
